### PR TITLE
Get python version from PATH instead of using hardcoded /usr/bin/python.

### DIFF
--- a/bin/drozer
+++ b/bin/drozer
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/bin/drozer-complete
+++ b/bin/drozer-complete
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/bin/drozer-repository
+++ b/bin/drozer-repository
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import sys

--- a/src/drozer/cli/agent.py
+++ b/src/drozer/cli/agent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 import sys

--- a/src/drozer/cli/console.py
+++ b/src/drozer/cli/console.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 import sys

--- a/src/drozer/cli/exploit.py
+++ b/src/drozer/cli/exploit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 import sys

--- a/src/drozer/cli/payload.py
+++ b/src/drozer/cli/payload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 import sys

--- a/src/drozer/cli/server.py
+++ b/src/drozer/cli/server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 import sys

--- a/src/drozer/cli/ssl.py
+++ b/src/drozer/cli/ssl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 import sys


### PR DESCRIPTION
This will make it possible for drozer to run in virtualenvs.