### PR TITLE
Upgrade pyopenssl to run with new versions of OpenSSL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ from drozer import meta
 
 def find_files(src):
     matches = []
-    
+
     for root, dirnames, filenames in os.walk(src):
         matches.extend(map(lambda f: os.path.join(root, f), filenames))
-    
+
     return matches
 
 def find_libs(src):
     matches = []
-    
+
     for root, dirnames, filenames in os.walk(src):
         for filename in fnmatch.filter(dirnames, 'lib'):
             matches.extend(glob.glob(os.path.join(root, filename, "*", "*")))
@@ -23,7 +23,7 @@ def find_libs(src):
             matches.extend(glob.glob(os.path.join(root, filename, "*", "*")))
 
     return map(lambda fn: os.path.basename(fn), filter(lambda fn: os.path.isfile(fn), matches))
-    
+
 setuptools.setup(
   name = meta.name,
   version = str(meta.version),
@@ -49,5 +49,5 @@ setuptools.setup(
                               "lib/weasel/armeabi/w",
                               "server/web_root/*" ] },
   scripts = ["bin/drozer", "bin/drozer-complete"],
-  install_requires = ["protobuf==2.4.1", "pyopenssl==0.13"],
+  install_requires = ["protobuf==2.4.1", "pyopenssl==0.14"],
   classifiers = [])


### PR DESCRIPTION
Good morning, I'm running `Python 2.7.10`, `OpenSSL 1.0.2a` and `setuptools 17.1`. At the moment I get:

```
Downloading https://pypi.python.org/packages/source/p/pyOpenSSL/pyOpenSSL-0.13.tar.gz#md5=767bca18a71178ca353dff9e10941929
Processing pyOpenSSL-0.13.tar.gz
Writing /tmp/easy_install-S93TOt/pyOpenSSL-0.13/setup.cfg
Running pyOpenSSL-0.13/setup.py -q bdist_egg --dist-dir /tmp/easy_install-S93TOt/pyOpenSSL-0.13/egg-dist-tmp-G5ljIs
warning: no previously-included files matching '*.pyc' found anywhere in distribution
OpenSSL/crypto/crl.c:6:23: error: static declaration of ‘X509_REVOKED_dup’ follows non-static declaration
 static X509_REVOKED * X509_REVOKED_dup(X509_REVOKED *orig) {
                       ^
In file included from /usr/include/openssl/ssl.h:156:0,
                 from OpenSSL/crypto/x509.h:17,
                 from OpenSSL/crypto/crypto.h:30,
                 from OpenSSL/crypto/crl.c:3:
/usr/include/openssl/x509.h:751:15: note: previous declaration of ‘X509_REVOKED_dup’ was here
 X509_REVOKED *X509_REVOKED_dup(X509_REVOKED *rev);
```

This pull request pretty much fixes the issue, already reported here: https://github.com/mwrlabs/drozer/issues/155
