### PR TITLE
Update pyOpenSSL requirement version to 0.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setuptools.setup(
                               "lib/weasel/armeabi/w",
                               "server/web_root/*" ] },
   scripts = ["bin/drozer", "bin/drozer-complete"],
-  install_requires = ["protobuf==2.4.1", "pyopenssl==0.13"],
+  install_requires = ["protobuf==2.4.1", "pyopenssl==0.14"],
   classifiers = [])

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setuptools.setup(
                               "lib/weasel/armeabi/w",
                               "server/web_root/*" ] },
   scripts = ["bin/drozer", "bin/drozer-complete"],
-  install_requires = ["protobuf==2.4.1", "pyopenssl==0.14"],
+  install_requires = ["protobuf==2.4.1", "pyopenssl==0.15"],
   classifiers = [])


### PR DESCRIPTION
This is pull request for #155 

Following command was failing due to required version of pyOpenSSL.
Therefore, I updated it.

```
easy_install ./drozer-2.3.4-py2.7.egg 
```

```setup.py
OpenSSL/crypto/crl.c:6:23: error: static declaration of 'X509_REVOKED_dup' follows non-static declaration
static X509_REVOKED * X509_REVOKED_dup(X509_REVOKED *orig) {
                      ^
/usr/local/opt/openssl/include/openssl/x509.h:751:15: note: previous declaration is here
X509_REVOKED *X509_REVOKED_dup(X509_REVOKED *rev);
              ^
```