### PR TITLE
Updated apktool to fix errors while building the social engineering exploit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setuptools.setup(
                               "lib/weasel/armeabi/w",
                               "server/web_root/*" ] },
   scripts = ["bin/drozer", "bin/drozer-complete"],
-  install_requires = ["protobuf==2.4.1", "pyopenssl==0.13"],
+  install_requires = ["protobuf==2.6.1", "pyopenssl==0.13"],
   classifiers = [])

--- a/src/drozer/agent/builder.py
+++ b/src/drozer/agent/builder.py
@@ -44,7 +44,7 @@ class Packager(command_wrapper.Wrapper):
         else:
             aapt = self.__aapt
         
-        if self._execute([self.__java, "-jar", self.__apk_tool, "-q", "build", "-a", aapt, self.source_dir(), self.apk_path(False)]) != 0:
+        if self._execute([self.__java, "-jar", self.__apk_tool, "build", self.source_dir(), "-o",self.apk_path(False)]) != 0:
             raise RuntimeError("could not repack the agent sources")
         if self._execute([self.__java, "-jar", self.__sign_apk, self.__certificate, self.__key, self.apk_path(False), self.apk_path(True)]) != 0:
             raise RuntimeError("could not sign the agent package")
@@ -55,5 +55,5 @@ class Packager(command_wrapper.Wrapper):
         return os.path.join(self.__wd, "agent")
     
     def unpack(self, name):
-        if self._execute([self.__java, "-jar", self.__apk_tool, "-q", "decode", Configuration.library(name + ".apk"), self.source_dir()]) != 0:
+        if self._execute([self.__java, "-jar", self.__apk_tool,"decode", Configuration.library(name + ".apk"), "-o",self.source_dir()]) != 0:
             raise RuntimeError("could not unpack " + name)

--- a/src/drozer/modules/exploit/soceng/unknown_sources.py
+++ b/src/drozer/modules/exploit/soceng/unknown_sources.py
@@ -71,7 +71,7 @@ class UnknownSources(Module, common.Exploit):
             return
         
         print "Uploading web delivery page to %s..." % path,
-        if not self.upload(arguments, path, self.build_multipart({ ".*Android.*": self.__template }, "gc0p4Jq0M2Yt08jU534c0p"), mimetype="text/html", headers={ "X-Drozer-Vary-UA": "true; boundary=gc0p4Jq0M2Yt08jU534c0p" }):
+        if not self.upload(arguments, path, self.build_multipart({ ".*Android.*": self.__template }, "gc0p4Jq0M2Yt08jU534c0p"), mimetype="text/html"):
             return
         
         print "Done. Exploit delivery page is available on: http://%s:%d%s" % (arguments.server[0], arguments.server[1], path.replace("\\",""))

--- a/src/drozer/modules/exploit/soceng/unknown_sources.py
+++ b/src/drozer/modules/exploit/soceng/unknown_sources.py
@@ -74,5 +74,8 @@ class UnknownSources(Module, common.Exploit):
         if not self.upload(arguments, path, self.build_multipart({ ".*Android.*": self.__template }, "gc0p4Jq0M2Yt08jU534c0p"), mimetype="text/html"):
             return
         
-        print "Done. Exploit delivery page is available on: http://%s:%d%s" % (arguments.server[0], arguments.server[1], path.replace("\\",""))
+        if hasattr(arguments, 'push_server') and arguments.push_server != None:
+            print "Done. Exploit delivery page is available on: http://%s:%d%s" % (arguments.push_server[0], arguments.push_server[1], path.replace("\\",""))
+        else:
+            print "Done. Exploit delivery page is available on: http://%s:%d%s" % (arguments.server[0], arguments.server[1], path.replace("\\",""))
         


### PR DESCRIPTION
The older version of apktool was unable to unpack rogue-agent when attempting to build an exploit. This fix replaces the older apktool with apktool v2.0. The commandline arguments for apktool have been updated for the newer version.
 
setup.py was updated to use python-protobuf v2.6 so that the build would complete without complaining.