### PR TITLE
fixed bug in web delivery page

### DIFF
--- a/src/drozer/modules/exploit/soceng/unknown_sources.py
+++ b/src/drozer/modules/exploit/soceng/unknown_sources.py
@@ -71,8 +71,11 @@ class UnknownSources(Module, common.Exploit):
             return
         
         print "Uploading web delivery page to %s..." % path,
-        if not self.upload(arguments, path, self.build_multipart({ ".*Android.*": self.__template }, "gc0p4Jq0M2Yt08jU534c0p"), mimetype="text/html", headers={ "X-Drozer-Vary-UA": "true; boundary=gc0p4Jq0M2Yt08jU534c0p" }):
+        if not self.upload(arguments, path, self.__template, mimetype="text/html"):
             return
         
-        print "Done. Exploit delivery page is available on: http://%s:%d%s" % (arguments.server[0], arguments.server[1], path.replace("\\",""))
+        if hasattr(arguments, 'push_server') and arguments.push_server != None:
+            print "Done. Exploit delivery page is available on: http://%s:%d%s" % (arguments.push_server[0], arguments.push_server[1], path.replace("\\",""))
+        else:
+            print "Done. Exploit delivery page is available on: http://%s:%d%s" % (arguments.server[0], arguments.server[1], path.replace("\\",""))
         


### PR DESCRIPTION
build_multipart doesn't process the html template for the soceng exploit correctly, causing the upload of the web delivery page to fail. This is most likely from the incomplete or incorrect implementation of build_multipart. 
 
This fix skips the multipart processing on the html template.

