### PR TITLE
Fix: python setup.py [build/install]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,19 @@ import glob
 import os
 import setuptools
 
-from drozer import meta
+from src.drozer import meta
 
 def find_files(src):
     matches = []
-    
+
     for root, dirnames, filenames in os.walk(src):
         matches.extend(map(lambda f: os.path.join(root, f), filenames))
-    
+
     return matches
 
 def find_libs(src):
     matches = []
-    
+
     for root, dirnames, filenames in os.walk(src):
         for filename in fnmatch.filter(dirnames, 'lib'):
             matches.extend(glob.glob(os.path.join(root, filename, "*", "*")))
@@ -23,7 +23,7 @@ def find_libs(src):
             matches.extend(glob.glob(os.path.join(root, filename, "*", "*")))
 
     return map(lambda fn: os.path.basename(fn), filter(lambda fn: os.path.isfile(fn), matches))
-    
+
 setuptools.setup(
   name = meta.name,
   version = str(meta.version),


### PR DESCRIPTION
- https://github.com/mwrlabs/drozer/issues/148
- https://github.com/mwrlabs/drozer/issues/222

This is a simple way for the error. It's better to use virtualenv for cross-platform.

```
(drozer) drozer [pip_install] ->> python setup.py build
Traceback (most recent call last):
  File "setup.py", line 6, in <module>
    from drozer import meta
ImportError: No module named drozer
```

```
(drozer) root@sh:~/andriod_security/drozer# uname -a
Linux sh 4.6.0-kali1-686-pae #1 SMP Debian 4.6.4-1kali1 (2016-07-21) i686 GNU/Linux


(drozer) root@sh:~/andriod_security/drozer# python setup.py install
running install
running bdist_egg
running egg_info
writing requirements to drozer.egg-info/requires.txt
writing drozer.egg-info/PKG-INFO
writing top-level names to drozer.egg-info/top_level.txt
writing dependency_links to drozer.egg-info/dependency_links.txt
reading manifest file 'drozer.egg-info/SOURCES.txt'
writing manifest file 'drozer.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-i686/egg
running install_lib
running build_py
creating build/bdist.linux-i686/egg
creating build/bdist.linux-i686/egg/drozer
creating build/bdist.linux-i686/egg/drozer/cli
copying build/lib.linux-i686-2.7/drozer/cli/module.py -> build/bdist.linux-i686/egg/drozer/cli
copying build/lib.linux-i686-2.7/drozer/cli/agent.py -> build/bdist.linux-i686/egg/drozer/cli
copying build/lib.linux-i686-2.7/drozer/cli/server.py -> build/bdist.linux-i686/egg/drozer/cli
copying build/lib.linux-i686-2.7/drozer/cli/payload.py -> build/bdist.linux-i686/egg/drozer/cli
copying build/lib.linux-i686-2.7/drozer/cli/ssl.py -> build/bdist.linux-i686/egg/drozer/cli
copying build/lib.linux-i686-2.7/drozer/cli/exploit.py -> build/bdist.linux-i686/egg/drozer/cli
copying build/lib.linux-i686-2.7/drozer/cli/__init__.py -> build/bdist.linux-i686/egg/drozer/cli
copying build/lib.linux-i686-2.7/drozer/cli/console.py -> build/bdist.linux-i686/egg/drozer/cli
creating build/bdist.linux-i686/egg/drozer/console
copying build/lib.linux-i686-2.7/drozer/console/clean.py -> build/bdist.linux-i686/egg/drozer/console
copying build/lib.linux-i686-2.7/drozer/console/session.py -> build/bdist.linux-i686/egg/drozer/console
copying build/lib.linux-i686-2.7/drozer/console/__init__.py -> build/bdist.linux-i686/egg/drozer/console
copying build/lib.linux-i686-2.7/drozer/console/console.py -> build/bdist.linux-i686/egg/drozer/console
copying build/lib.linux-i686-2.7/drozer/console/sequencer.py -> build/bdist.linux-i686/egg/drozer/console
creating build/bdist.linux-i686/egg/drozer/ssl
creating build/bdist.linux-i686/egg/drozer/ssl/embedded_ca
copying build/lib.linux-i686-2.7/drozer/ssl/embedded_ca/drozer-ca.crt -> build/bdist.linux-i686/egg/drozer/ssl/embedded_ca
copying build/lib.linux-i686-2.7/drozer/ssl/embedded_ca/drozer-ca.bks -> build/bdist.linux-i686/egg/drozer/ssl/embedded_ca
copying build/lib.linux-i686-2.7/drozer/ssl/embedded_ca/drozer-ca.key -> build/bdist.linux-i686/egg/drozer/ssl/embedded_ca
copying build/lib.linux-i686-2.7/drozer/ssl/embedded_ca/drozer-server.key -> build/bdist.linux-i686/egg/drozer/ssl/embedded_ca
copying build/lib.linux-i686-2.7/drozer/ssl/embedded_ca/drozer-server.crt -> build/bdist.linux-i686/egg/drozer/ssl/embedded_ca
copying build/lib.linux-i686-2.7/drozer/ssl/embedded_ca/__init__.py -> build/bdist.linux-i686/egg/drozer/ssl/embedded_ca
copying build/lib.linux-i686-2.7/drozer/ssl/bcprov-ext-jdk15on-1.46.jar -> build/bdist.linux-i686/egg/drozer/ssl
copying build/lib.linux-i686-2.7/drozer/ssl/provider.py -> build/bdist.linux-i686/egg/drozer/ssl
copying build/lib.linux-i686-2.7/drozer/ssl/ca.py -> build/bdist.linux-i686/egg/drozer/ssl
copying build/lib.linux-i686-2.7/drozer/ssl/ssl_manager.py -> build/bdist.linux-i686/egg/drozer/ssl
copying build/lib.linux-i686-2.7/drozer/ssl/__init__.py -> build/bdist.linux-i686/egg/drozer/ssl
creating build/bdist.linux-i686/egg/drozer/connector
copying build/lib.linux-i686-2.7/drozer/connector/server_connector.py -> build/bdist.linux-i686/egg/drozer/connector
copying build/lib.linux-i686-2.7/drozer/connector/__init__.py -> build/bdist.linux-i686/egg/drozer/connector
creating build/bdist.linux-i686/egg/drozer/api
creating build/bdist.linux-i686/egg/drozer/api/formatters
copying build/lib.linux-i686-2.7/drozer/api/formatters/system_response.py -> build/bdist.linux-i686/egg/drozer/api/formatters
copying build/lib.linux-i686-2.7/drozer/api/formatters/__init__.py -> build/bdist.linux-i686/egg/drozer/api/formatters
copying build/lib.linux-i686-2.7/drozer/api/__init__.py -> build/bdist.linux-i686/egg/drozer/api
creating build/bdist.linux-i686/egg/drozer/api/handlers
copying build/lib.linux-i686-2.7/drozer/api/handlers/system_response_handler.py -> build/bdist.linux-i686/egg/drozer/api/handlers
copying build/lib.linux-i686-2.7/drozer/api/handlers/reflection_response_forwarder.py -> build/bdist.linux-i686/egg/drozer/api/handlers
copying build/lib.linux-i686-2.7/drozer/api/handlers/reflection_request_forwarder.py -> build/bdist.linux-i686/egg/drozer/api/handlers
copying build/lib.linux-i686-2.7/drozer/api/handlers/system_request_handler.py -> build/bdist.linux-i686/egg/drozer/api/handlers
copying build/lib.linux-i686-2.7/drozer/api/handlers/__init__.py -> build/bdist.linux-i686/egg/drozer/api/handlers
creating build/bdist.linux-i686/egg/drozer/agent
copying build/lib.linux-i686-2.7/drozer/agent/manager.py -> build/bdist.linux-i686/egg/drozer/agent
copying build/lib.linux-i686-2.7/drozer/agent/builder.py -> build/bdist.linux-i686/egg/drozer/agent
copying build/lib.linux-i686-2.7/drozer/agent/__init__.py -> build/bdist.linux-i686/egg/drozer/agent
copying build/lib.linux-i686-2.7/drozer/agent/manifest.py -> build/bdist.linux-i686/egg/drozer/agent
copying build/lib.linux-i686-2.7/drozer/session.py -> build/bdist.linux-i686/egg/drozer
creating build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/standard-agent.apk -> build/bdist.linux-i686/egg/drozer/lib
creating build/bdist.linux-i686/egg/drozer/lib/weasel
creating build/bdist.linux-i686/egg/drozer/lib/weasel/armeabi
copying build/lib.linux-i686-2.7/drozer/lib/weasel/armeabi/w -> build/bdist.linux-i686/egg/drozer/lib/weasel/armeabi
copying build/lib.linux-i686-2.7/drozer/lib/android.jar -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/aapt.exe -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/agent.jar -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/aapt -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/aapt-osx -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/protobuf-java-2.6.1.jar -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/apktool.jar -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/dx.jar -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/key.pk8 -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/certificate.pem -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/rogue-agent.apk -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/signapk.jar -> build/bdist.linux-i686/egg/drozer/lib
copying build/lib.linux-i686-2.7/drozer/lib/android-support-v4.jar -> build/bdist.linux-i686/egg/drozer/lib
creating build/bdist.linux-i686/egg/drozer/server
copying build/lib.linux-i686-2.7/drozer/server/files.py -> build/bdist.linux-i686/egg/drozer/server
copying build/lib.linux-i686-2.7/drozer/server/dz.py -> build/bdist.linux-i686/egg/drozer/server
copying build/lib.linux-i686-2.7/drozer/server/heartbeat.py -> build/bdist.linux-i686/egg/drozer/server
creating build/bdist.linux-i686/egg/drozer/server/receivers
copying build/lib.linux-i686-2.7/drozer/server/receivers/http.py -> build/bdist.linux-i686/egg/drozer/server/receivers
copying build/lib.linux-i686-2.7/drozer/server/receivers/frame.py -> build/bdist.linux-i686/egg/drozer/server/receivers
copying build/lib.linux-i686-2.7/drozer/server/receivers/__init__.py -> build/bdist.linux-i686/egg/drozer/server/receivers
copying build/lib.linux-i686-2.7/drozer/server/server.py -> build/bdist.linux-i686/egg/drozer/server
copying build/lib.linux-i686-2.7/drozer/server/uploader.py -> build/bdist.linux-i686/egg/drozer/server
creating build/bdist.linux-i686/egg/drozer/server/protocols
copying build/lib.linux-i686-2.7/drozer/server/protocols/http.py -> build/bdist.linux-i686/egg/drozer/server/protocols
copying build/lib.linux-i686-2.7/drozer/server/protocols/drozerp.py -> build/bdist.linux-i686/egg/drozer/server/protocols
copying build/lib.linux-i686-2.7/drozer/server/protocols/shell.py -> build/bdist.linux-i686/egg/drozer/server/protocols
copying build/lib.linux-i686-2.7/drozer/server/protocols/byte_stream.py -> build/bdist.linux-i686/egg/drozer/server/protocols
copying build/lib.linux-i686-2.7/drozer/server/protocols/__init__.py -> build/bdist.linux-i686/egg/drozer/server/protocols
creating build/bdist.linux-i686/egg/drozer/server/web_root
copying build/lib.linux-i686-2.7/drozer/server/web_root/favicon.png -> build/bdist.linux-i686/egg/drozer/server/web_root
copying build/lib.linux-i686-2.7/drozer/server/web_root/index.html -> build/bdist.linux-i686/egg/drozer/server/web_root
copying build/lib.linux-i686-2.7/drozer/server/web_root/drozer.png -> build/bdist.linux-i686/egg/drozer/server/web_root
copying build/lib.linux-i686-2.7/drozer/server/web_root/labs.png -> build/bdist.linux-i686/egg/drozer/server/web_root
copying build/lib.linux-i686-2.7/drozer/server/web_root/jquery.js -> build/bdist.linux-i686/egg/drozer/server/web_root
copying build/lib.linux-i686-2.7/drozer/server/__init__.py -> build/bdist.linux-i686/egg/drozer/server
copying build/lib.linux-i686-2.7/drozer/meta.py -> build/bdist.linux-i686/egg/drozer
copying build/lib.linux-i686-2.7/drozer/android.py -> build/bdist.linux-i686/egg/drozer
copying build/lib.linux-i686-2.7/drozer/configuration.py -> build/bdist.linux-i686/egg/drozer
creating build/bdist.linux-i686/egg/drozer/payload
copying build/lib.linux-i686-2.7/drozer/payload/manager.py -> build/bdist.linux-i686/egg/drozer/payload
copying build/lib.linux-i686-2.7/drozer/payload/builder.py -> build/bdist.linux-i686/egg/drozer/payload
copying build/lib.linux-i686-2.7/drozer/payload/__init__.py -> build/bdist.linux-i686/egg/drozer/payload
copying build/lib.linux-i686-2.7/drozer/util.py -> build/bdist.linux-i686/egg/drozer
copying build/lib.linux-i686-2.7/drozer/device.py -> build/bdist.linux-i686/egg/drozer
creating build/bdist.linux-i686/egg/drozer/modules
copying build/lib.linux-i686-2.7/drozer/modules/loader.py -> build/bdist.linux-i686/egg/drozer/modules
copying build/lib.linux-i686-2.7/drozer/modules/base.py -> build/bdist.linux-i686/egg/drozer/modules
creating build/bdist.linux-i686/egg/drozer/modules/information
copying build/lib.linux-i686-2.7/drozer/modules/information/device_info.py -> build/bdist.linux-i686/egg/drozer/modules/information
copying build/lib.linux-i686-2.7/drozer/modules/information/datetime.py -> build/bdist.linux-i686/egg/drozer/modules/information
copying build/lib.linux-i686-2.7/drozer/modules/information/permissions.py -> build/bdist.linux-i686/egg/drozer/modules/information
copying build/lib.linux-i686-2.7/drozer/modules/information/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/information
creating build/bdist.linux-i686/egg/drozer/modules/shell
copying build/lib.linux-i686-2.7/drozer/modules/shell/startexec.py -> build/bdist.linux-i686/egg/drozer/modules/shell
copying build/lib.linux-i686-2.7/drozer/modules/shell/send.py -> build/bdist.linux-i686/egg/drozer/modules/shell
copying build/lib.linux-i686-2.7/drozer/modules/shell/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/shell
creating build/bdist.linux-i686/egg/drozer/modules/scanner
creating build/bdist.linux-i686/egg/drozer/modules/scanner/oem
copying build/lib.linux-i686-2.7/drozer/modules/scanner/oem/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/oem
creating build/bdist.linux-i686/egg/drozer/modules/scanner/activity
copying build/lib.linux-i686-2.7/drozer/modules/scanner/activity/browsable.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/activity
copying build/lib.linux-i686-2.7/drozer/modules/scanner/activity/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/activity
creating build/bdist.linux-i686/egg/drozer/modules/scanner/provider
copying build/lib.linux-i686-2.7/drozer/modules/scanner/provider/traversal.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/provider
copying build/lib.linux-i686-2.7/drozer/modules/scanner/provider/find_uris.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/provider
copying build/lib.linux-i686-2.7/drozer/modules/scanner/provider/sql_table_dump.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/provider
copying build/lib.linux-i686-2.7/drozer/modules/scanner/provider/injection.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/provider
copying build/lib.linux-i686-2.7/drozer/modules/scanner/provider/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/provider
creating build/bdist.linux-i686/egg/drozer/modules/scanner/misc
copying build/lib.linux-i686-2.7/drozer/modules/scanner/misc/readable_files.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/misc
copying build/lib.linux-i686-2.7/drozer/modules/scanner/misc/secretcodes.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/misc
copying build/lib.linux-i686-2.7/drozer/modules/scanner/misc/sflag_binaries.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/misc
copying build/lib.linux-i686-2.7/drozer/modules/scanner/misc/native.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/misc
copying build/lib.linux-i686-2.7/drozer/modules/scanner/misc/writable_files.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/misc
copying build/lib.linux-i686-2.7/drozer/modules/scanner/misc/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/scanner/misc
copying build/lib.linux-i686-2.7/drozer/modules/scanner/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/scanner
creating build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/strings.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/filtering.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/loader.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/superuser.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/file_system.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/intent_filter.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/busy_box.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/formatter.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/shell.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/package_manager.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/assets.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/provider.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/shell_code.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/path_completion.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/exploit.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/zip_file.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/binding.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/vulnerability.py -> build/bdist.linux-i686/egg/drozer/modules/common
copying build/lib.linux-i686-2.7/drozer/modules/common/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/common
creating build/bdist.linux-i686/egg/drozer/modules/app
copying build/lib.linux-i686-2.7/drozer/modules/app/backup.py -> build/bdist.linux-i686/egg/drozer/modules/app
copying build/lib.linux-i686-2.7/drozer/modules/app/broadcast.py -> build/bdist.linux-i686/egg/drozer/modules/app
copying build/lib.linux-i686-2.7/drozer/modules/app/package.py -> build/bdist.linux-i686/egg/drozer/modules/app
copying build/lib.linux-i686-2.7/drozer/modules/app/provider.py -> build/bdist.linux-i686/egg/drozer/modules/app
copying build/lib.linux-i686-2.7/drozer/modules/app/debuggable.py -> build/bdist.linux-i686/egg/drozer/modules/app
copying build/lib.linux-i686-2.7/drozer/modules/app/service.py -> build/bdist.linux-i686/egg/drozer/modules/app
copying build/lib.linux-i686-2.7/drozer/modules/app/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/app
copying build/lib.linux-i686-2.7/drozer/modules/app/activity.py -> build/bdist.linux-i686/egg/drozer/modules/app
creating build/bdist.linux-i686/egg/drozer/modules/tools
creating build/bdist.linux-i686/egg/drozer/modules/tools/setup
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/su.py -> build/bdist.linux-i686/egg/drozer/modules/tools/setup
creating build/bdist.linux-i686/egg/drozer/modules/tools/setup/nopie
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/nopie/busybox -> build/bdist.linux-i686/egg/drozer/modules/tools/setup/nopie
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/nopie/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/tools/setup/nopie
creating build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su
creating build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su/libs
creating build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su/libs/armeabi
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/minimal-su/libs/armeabi/su -> build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su/libs/armeabi
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/minimal-su/libs/armeabi/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su/libs/armeabi
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/minimal-su/libs/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su/libs
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/minimal-su/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su
creating build/bdist.linux-i686/egg/drozer/modules/tools/setup/pie
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/pie/busybox -> build/bdist.linux-i686/egg/drozer/modules/tools/setup/pie
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/pie/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/tools/setup/pie
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/busybox.py -> build/bdist.linux-i686/egg/drozer/modules/tools/setup
copying build/lib.linux-i686-2.7/drozer/modules/tools/setup/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/tools/setup
copying build/lib.linux-i686-2.7/drozer/modules/tools/file.py -> build/bdist.linux-i686/egg/drozer/modules/tools
copying build/lib.linux-i686-2.7/drozer/modules/tools/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/tools
creating build/bdist.linux-i686/egg/drozer/modules/auxiliary
copying build/lib.linux-i686-2.7/drozer/modules/auxiliary/web_content_resolver.py -> build/bdist.linux-i686/egg/drozer/modules/auxiliary
copying build/lib.linux-i686-2.7/drozer/modules/auxiliary/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/auxiliary
creating build/bdist.linux-i686/egg/drozer/modules/exploit
creating build/bdist.linux-i686/egg/drozer/modules/exploit/soceng
copying build/lib.linux-i686-2.7/drozer/modules/exploit/soceng/usb_debugging.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/soceng
copying build/lib.linux-i686-2.7/drozer/modules/exploit/soceng/unknown_sources.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/soceng
copying build/lib.linux-i686-2.7/drozer/modules/exploit/soceng/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/soceng
creating build/bdist.linux-i686/egg/drozer/modules/exploit/browser
copying build/lib.linux-i686-2.7/drozer/modules/exploit/browser/use_after_free_2_1.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/browser
copying build/lib.linux-i686-2.7/drozer/modules/exploit/browser/samsung_knox_smdm.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/browser
copying build/lib.linux-i686-2.7/drozer/modules/exploit/browser/nan_parse.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/browser
copying build/lib.linux-i686-2.7/drozer/modules/exploit/browser/normalize.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/browser
copying build/lib.linux-i686-2.7/drozer/modules/exploit/browser/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/browser
creating build/bdist.linux-i686/egg/drozer/modules/exploit/jdwp
copying build/lib.linux-i686-2.7/drozer/modules/exploit/jdwp/check.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/jdwp
copying build/lib.linux-i686-2.7/drozer/modules/exploit/jdwp/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/jdwp
creating build/bdist.linux-i686/egg/drozer/modules/exploit/root
copying build/lib.linux-i686-2.7/drozer/modules/exploit/root/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/root
creating build/bdist.linux-i686/egg/drozer/modules/exploit/webview
copying build/lib.linux-i686-2.7/drozer/modules/exploit/webview/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/webview
copying build/lib.linux-i686-2.7/drozer/modules/exploit/webview/addJavaScriptInterface.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/webview
creating build/bdist.linux-i686/egg/drozer/modules/exploit/mitm
copying build/lib.linux-i686-2.7/drozer/modules/exploit/mitm/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/mitm
creating build/bdist.linux-i686/egg/drozer/modules/exploit/dos
copying build/lib.linux-i686-2.7/drozer/modules/exploit/dos/remote_wipe.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/dos
copying build/lib.linux-i686-2.7/drozer/modules/exploit/dos/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/dos
creating build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer
creating build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/oem
copying build/lib.linux-i686-2.7/drozer/modules/exploit/pilfer/oem/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/oem
creating build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/general
copying build/lib.linux-i686-2.7/drozer/modules/exploit/pilfer/general/apn_provider.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/general
copying build/lib.linux-i686-2.7/drozer/modules/exploit/pilfer/general/settings_provider.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/general
copying build/lib.linux-i686-2.7/drozer/modules/exploit/pilfer/general/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/general
creating build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/thirdparty
copying build/lib.linux-i686-2.7/drozer/modules/exploit/pilfer/thirdparty/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/thirdparty
copying build/lib.linux-i686-2.7/drozer/modules/exploit/pilfer/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer
creating build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat
copying build/lib.linux-i686-2.7/drozer/modules/exploit/fileformat/ca89ef3ffa6f48ca4147387638559d94.docx -> build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat
creating build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat/polaris_viewer4_generate
copying build/lib.linux-i686-2.7/drozer/modules/exploit/fileformat/polaris_viewer4_generate/orig_document.xml -> build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat/polaris_viewer4_generate
copying build/lib.linux-i686-2.7/drozer/modules/exploit/fileformat/polaris_viewer4_generate/polaris_viewer4_bof_generator.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat/polaris_viewer4_generate
copying build/lib.linux-i686-2.7/drozer/modules/exploit/fileformat/polaris_viewer4_generate/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat/polaris_viewer4_generate
copying build/lib.linux-i686-2.7/drozer/modules/exploit/fileformat/polaris_viewer4_bof_web.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat
copying build/lib.linux-i686-2.7/drozer/modules/exploit/fileformat/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat
copying build/lib.linux-i686-2.7/drozer/modules/exploit/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/exploit
copying build/lib.linux-i686-2.7/drozer/modules/__init__.py -> build/bdist.linux-i686/egg/drozer/modules
copying build/lib.linux-i686-2.7/drozer/modules/import_conflict_resolver.py -> build/bdist.linux-i686/egg/drozer/modules
copying build/lib.linux-i686-2.7/drozer/modules/collection.py -> build/bdist.linux-i686/egg/drozer/modules
creating build/bdist.linux-i686/egg/drozer/modules/payloads
copying build/lib.linux-i686-2.7/drozer/modules/payloads/weasel.py -> build/bdist.linux-i686/egg/drozer/modules/payloads
creating build/bdist.linux-i686/egg/drozer/modules/payloads/shellcode
copying build/lib.linux-i686-2.7/drozer/modules/payloads/shellcode/reverse_tcp_shell.py -> build/bdist.linux-i686/egg/drozer/modules/payloads/shellcode
copying build/lib.linux-i686-2.7/drozer/modules/payloads/shellcode/reverse_weasel.py -> build/bdist.linux-i686/egg/drozer/modules/payloads/shellcode
copying build/lib.linux-i686-2.7/drozer/modules/payloads/shellcode/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/payloads/shellcode
copying build/lib.linux-i686-2.7/drozer/modules/payloads/__init__.py -> build/bdist.linux-i686/egg/drozer/modules/payloads
creating build/bdist.linux-i686/egg/drozer/exploit
copying build/lib.linux-i686-2.7/drozer/exploit/manager.py -> build/bdist.linux-i686/egg/drozer/exploit
copying build/lib.linux-i686-2.7/drozer/exploit/builder.py -> build/bdist.linux-i686/egg/drozer/exploit
copying build/lib.linux-i686-2.7/drozer/exploit/__init__.py -> build/bdist.linux-i686/egg/drozer/exploit
copying build/lib.linux-i686-2.7/drozer/__init__.py -> build/bdist.linux-i686/egg/drozer
creating build/bdist.linux-i686/egg/drozer/repoman
copying build/lib.linux-i686-2.7/drozer/repoman/remotes.py -> build/bdist.linux-i686/egg/drozer/repoman
copying build/lib.linux-i686-2.7/drozer/repoman/repository_builder.py -> build/bdist.linux-i686/egg/drozer/repoman
copying build/lib.linux-i686-2.7/drozer/repoman/manager.py -> build/bdist.linux-i686/egg/drozer/repoman
copying build/lib.linux-i686-2.7/drozer/repoman/repositories.py -> build/bdist.linux-i686/egg/drozer/repoman
copying build/lib.linux-i686-2.7/drozer/repoman/__init__.py -> build/bdist.linux-i686/egg/drozer/repoman
copying build/lib.linux-i686-2.7/drozer/repoman/installer.py -> build/bdist.linux-i686/egg/drozer/repoman
creating build/bdist.linux-i686/egg/pydiesel
creating build/bdist.linux-i686/egg/pydiesel/api
copying build/lib.linux-i686-2.7/pydiesel/api/frame.py -> build/bdist.linux-i686/egg/pydiesel/api
copying build/lib.linux-i686-2.7/pydiesel/api/protobuf_pb2.py -> build/bdist.linux-i686/egg/pydiesel/api
copying build/lib.linux-i686-2.7/pydiesel/api/exceptions.py -> build/bdist.linux-i686/egg/pydiesel/api
creating build/bdist.linux-i686/egg/pydiesel/api/transport
copying build/lib.linux-i686-2.7/pydiesel/api/transport/exceptions.py -> build/bdist.linux-i686/egg/pydiesel/api/transport
copying build/lib.linux-i686-2.7/pydiesel/api/transport/socket_transport.py -> build/bdist.linux-i686/egg/pydiesel/api/transport
copying build/lib.linux-i686-2.7/pydiesel/api/transport/transport.py -> build/bdist.linux-i686/egg/pydiesel/api/transport
copying build/lib.linux-i686-2.7/pydiesel/api/transport/__init__.py -> build/bdist.linux-i686/egg/pydiesel/api/transport
copying build/lib.linux-i686-2.7/pydiesel/api/__init__.py -> build/bdist.linux-i686/egg/pydiesel/api
creating build/bdist.linux-i686/egg/pydiesel/api/builders
copying build/lib.linux-i686-2.7/pydiesel/api/builders/reflection_response.py -> build/bdist.linux-i686/egg/pydiesel/api/builders
copying build/lib.linux-i686-2.7/pydiesel/api/builders/reflection_request.py -> build/bdist.linux-i686/egg/pydiesel/api/builders
copying build/lib.linux-i686-2.7/pydiesel/api/builders/system_request.py -> build/bdist.linux-i686/egg/pydiesel/api/builders
copying build/lib.linux-i686-2.7/pydiesel/api/builders/system_response.py -> build/bdist.linux-i686/egg/pydiesel/api/builders
copying build/lib.linux-i686-2.7/pydiesel/api/builders/__init__.py -> build/bdist.linux-i686/egg/pydiesel/api/builders
creating build/bdist.linux-i686/egg/pydiesel/api/handlers
copying build/lib.linux-i686-2.7/pydiesel/api/handlers/system_response_handler.py -> build/bdist.linux-i686/egg/pydiesel/api/handlers
copying build/lib.linux-i686-2.7/pydiesel/api/handlers/system_request_handler.py -> build/bdist.linux-i686/egg/pydiesel/api/handlers
copying build/lib.linux-i686-2.7/pydiesel/api/handlers/__init__.py -> build/bdist.linux-i686/egg/pydiesel/api/handlers
creating build/bdist.linux-i686/egg/pydiesel/reflection
creating build/bdist.linux-i686/egg/pydiesel/reflection/types
copying build/lib.linux-i686-2.7/pydiesel/reflection/types/reflected_primitive.py -> build/bdist.linux-i686/egg/pydiesel/reflection/types
copying build/lib.linux-i686-2.7/pydiesel/reflection/types/reflected_object.py -> build/bdist.linux-i686/egg/pydiesel/reflection/types
copying build/lib.linux-i686-2.7/pydiesel/reflection/types/reflected_type.py -> build/bdist.linux-i686/egg/pydiesel/reflection/types
copying build/lib.linux-i686-2.7/pydiesel/reflection/types/reflected_null.py -> build/bdist.linux-i686/egg/pydiesel/reflection/types
copying build/lib.linux-i686-2.7/pydiesel/reflection/types/reflected_binary.py -> build/bdist.linux-i686/egg/pydiesel/reflection/types
copying build/lib.linux-i686-2.7/pydiesel/reflection/types/reflected_string.py -> build/bdist.linux-i686/egg/pydiesel/reflection/types
copying build/lib.linux-i686-2.7/pydiesel/reflection/types/__init__.py -> build/bdist.linux-i686/egg/pydiesel/reflection/types
copying build/lib.linux-i686-2.7/pydiesel/reflection/types/reflected_array.py -> build/bdist.linux-i686/egg/pydiesel/reflection/types
copying build/lib.linux-i686-2.7/pydiesel/reflection/reflector.py -> build/bdist.linux-i686/egg/pydiesel/reflection
copying build/lib.linux-i686-2.7/pydiesel/reflection/exceptions.py -> build/bdist.linux-i686/egg/pydiesel/reflection
creating build/bdist.linux-i686/egg/pydiesel/reflection/utils
copying build/lib.linux-i686-2.7/pydiesel/reflection/utils/class_loader.py -> build/bdist.linux-i686/egg/pydiesel/reflection/utils
copying build/lib.linux-i686-2.7/pydiesel/reflection/utils/class_builder.py -> build/bdist.linux-i686/egg/pydiesel/reflection/utils
copying build/lib.linux-i686-2.7/pydiesel/reflection/utils/__init__.py -> build/bdist.linux-i686/egg/pydiesel/reflection/utils
copying build/lib.linux-i686-2.7/pydiesel/reflection/__init__.py -> build/bdist.linux-i686/egg/pydiesel/reflection
copying build/lib.linux-i686-2.7/pydiesel/__init__.py -> build/bdist.linux-i686/egg/pydiesel
creating build/bdist.linux-i686/egg/mwr
creating build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/stream.py -> build/bdist.linux-i686/egg/mwr/common
creating build/bdist.linux-i686/egg/mwr/common/twisted
copying build/lib.linux-i686-2.7/mwr/common/twisted/stream_receiver.py -> build/bdist.linux-i686/egg/mwr/common/twisted
copying build/lib.linux-i686-2.7/mwr/common/twisted/__init__.py -> build/bdist.linux-i686/egg/mwr/common/twisted
copying build/lib.linux-i686-2.7/mwr/common/command_wrapper.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/argparse_completer.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/cli.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/cmd_ext.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/text.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/path_completion.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/logger.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/list.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/__init__.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/fs.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/system.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/common/console.py -> build/bdist.linux-i686/egg/mwr/common
copying build/lib.linux-i686-2.7/mwr/__init__.py -> build/bdist.linux-i686/egg/mwr
byte-compiling build/bdist.linux-i686/egg/drozer/cli/module.py to module.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/cli/agent.py to agent.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/cli/server.py to server.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/cli/payload.py to payload.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/cli/ssl.py to ssl.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/cli/exploit.py to exploit.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/cli/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/cli/console.py to console.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/console/clean.py to clean.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/console/session.py to session.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/console/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/console/console.py to console.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/console/sequencer.py to sequencer.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/ssl/embedded_ca/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/ssl/provider.py to provider.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/ssl/ca.py to ca.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/ssl/ssl_manager.py to ssl_manager.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/ssl/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/connector/server_connector.py to server_connector.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/connector/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/api/formatters/system_response.py to system_response.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/api/formatters/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/api/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/api/handlers/system_response_handler.py to system_response_handler.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/api/handlers/reflection_response_forwarder.py to reflection_response_forwarder.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/api/handlers/reflection_request_forwarder.py to reflection_request_forwarder.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/api/handlers/system_request_handler.py to system_request_handler.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/api/handlers/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/agent/manager.py to manager.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/agent/builder.py to builder.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/agent/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/agent/manifest.py to manifest.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/session.py to session.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/files.py to files.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/dz.py to dz.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/heartbeat.py to heartbeat.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/receivers/http.py to http.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/receivers/frame.py to frame.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/receivers/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/server.py to server.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/uploader.py to uploader.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/protocols/http.py to http.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/protocols/drozerp.py to drozerp.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/protocols/shell.py to shell.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/protocols/byte_stream.py to byte_stream.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/protocols/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/server/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/meta.py to meta.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/android.py to android.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/configuration.py to configuration.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/payload/manager.py to manager.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/payload/builder.py to builder.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/payload/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/util.py to util.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/device.py to device.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/loader.py to loader.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/base.py to base.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/information/device_info.py to device_info.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/information/datetime.py to datetime.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/information/permissions.py to permissions.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/information/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/shell/startexec.py to startexec.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/shell/send.py to send.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/shell/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/oem/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/activity/browsable.py to browsable.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/activity/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/provider/traversal.py to traversal.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/provider/find_uris.py to find_uris.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/provider/sql_table_dump.py to sql_table_dump.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/provider/injection.py to injection.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/provider/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/misc/readable_files.py to readable_files.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/misc/secretcodes.py to secretcodes.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/misc/sflag_binaries.py to sflag_binaries.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/misc/native.py to native.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/misc/writable_files.py to writable_files.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/misc/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/scanner/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/strings.py to strings.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/filtering.py to filtering.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/loader.py to loader.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/superuser.py to superuser.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/file_system.py to file_system.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/intent_filter.py to intent_filter.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/busy_box.py to busy_box.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/formatter.py to formatter.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/shell.py to shell.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/package_manager.py to package_manager.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/assets.py to assets.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/provider.py to provider.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/shell_code.py to shell_code.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/path_completion.py to path_completion.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/exploit.py to exploit.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/zip_file.py to zip_file.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/binding.py to binding.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/vulnerability.py to vulnerability.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/common/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/app/backup.py to backup.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/app/broadcast.py to broadcast.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/app/package.py to package.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/app/provider.py to provider.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/app/debuggable.py to debuggable.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/app/service.py to service.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/app/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/app/activity.py to activity.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/setup/su.py to su.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/setup/nopie/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su/libs/armeabi/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su/libs/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/setup/minimal-su/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/setup/pie/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/setup/busybox.py to busybox.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/setup/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/file.py to file.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/tools/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/auxiliary/web_content_resolver.py to web_content_resolver.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/auxiliary/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/soceng/usb_debugging.py to usb_debugging.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/soceng/unknown_sources.py to unknown_sources.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/soceng/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/browser/use_after_free_2_1.py to use_after_free_2_1.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/browser/samsung_knox_smdm.py to samsung_knox_smdm.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/browser/nan_parse.py to nan_parse.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/browser/normalize.py to normalize.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/browser/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/jdwp/check.py to check.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/jdwp/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/root/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/webview/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/webview/addJavaScriptInterface.py to addJavaScriptInterface.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/mitm/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/dos/remote_wipe.py to remote_wipe.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/dos/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/oem/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/general/apn_provider.py to apn_provider.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/general/settings_provider.py to settings_provider.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/general/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/thirdparty/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/pilfer/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat/polaris_viewer4_generate/polaris_viewer4_bof_generator.py to polaris_viewer4_bof_generator.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat/polaris_viewer4_generate/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat/polaris_viewer4_bof_web.py to polaris_viewer4_bof_web.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/fileformat/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/exploit/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/import_conflict_resolver.py to import_conflict_resolver.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/collection.py to collection.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/payloads/weasel.py to weasel.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/payloads/shellcode/reverse_tcp_shell.py to reverse_tcp_shell.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/payloads/shellcode/reverse_weasel.py to reverse_weasel.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/payloads/shellcode/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/modules/payloads/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/exploit/manager.py to manager.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/exploit/builder.py to builder.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/exploit/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/repoman/remotes.py to remotes.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/repoman/repository_builder.py to repository_builder.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/repoman/manager.py to manager.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/repoman/repositories.py to repositories.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/repoman/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/drozer/repoman/installer.py to installer.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/frame.py to frame.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/protobuf_pb2.py to protobuf_pb2.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/exceptions.py to exceptions.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/transport/exceptions.py to exceptions.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/transport/socket_transport.py to socket_transport.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/transport/transport.py to transport.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/transport/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/builders/reflection_response.py to reflection_response.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/builders/reflection_request.py to reflection_request.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/builders/system_request.py to system_request.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/builders/system_response.py to system_response.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/builders/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/handlers/system_response_handler.py to system_response_handler.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/handlers/system_request_handler.py to system_request_handler.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/api/handlers/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/types/reflected_primitive.py to reflected_primitive.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/types/reflected_object.py to reflected_object.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/types/reflected_type.py to reflected_type.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/types/reflected_null.py to reflected_null.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/types/reflected_binary.py to reflected_binary.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/types/reflected_string.py to reflected_string.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/types/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/types/reflected_array.py to reflected_array.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/reflector.py to reflector.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/exceptions.py to exceptions.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/utils/class_loader.py to class_loader.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/utils/class_builder.py to class_builder.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/utils/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/reflection/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/pydiesel/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/stream.py to stream.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/twisted/stream_receiver.py to stream_receiver.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/twisted/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/command_wrapper.py to command_wrapper.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/argparse_completer.py to argparse_completer.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/cli.py to cli.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/cmd_ext.py to cmd_ext.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/text.py to text.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/path_completion.py to path_completion.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/logger.py to logger.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/list.py to list.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/fs.py to fs.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/system.py to system.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/common/console.py to console.pyc
byte-compiling build/bdist.linux-i686/egg/mwr/__init__.py to __init__.pyc
creating build/bdist.linux-i686/egg/EGG-INFO
installing scripts to build/bdist.linux-i686/egg/EGG-INFO/scripts
running install_scripts
running build_scripts
creating build/bdist.linux-i686/egg/EGG-INFO/scripts
copying build/scripts-2.7/drozer-complete -> build/bdist.linux-i686/egg/EGG-INFO/scripts
copying build/scripts-2.7/drozer -> build/bdist.linux-i686/egg/EGG-INFO/scripts
changing mode of build/bdist.linux-i686/egg/EGG-INFO/scripts/drozer-complete to 755
changing mode of build/bdist.linux-i686/egg/EGG-INFO/scripts/drozer to 755
copying drozer.egg-info/PKG-INFO -> build/bdist.linux-i686/egg/EGG-INFO
copying drozer.egg-info/SOURCES.txt -> build/bdist.linux-i686/egg/EGG-INFO
copying drozer.egg-info/dependency_links.txt -> build/bdist.linux-i686/egg/EGG-INFO
copying drozer.egg-info/requires.txt -> build/bdist.linux-i686/egg/EGG-INFO
copying drozer.egg-info/top_level.txt -> build/bdist.linux-i686/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
drozer.configuration: module references __file__
drozer.ssl.provider: module references __file__
drozer.server.dz: module references __file__
drozer.modules.loader: module references __file__
drozer.modules.common.busy_box: module references __file__
drozer.modules.common.loader: module references __file__
drozer.modules.common.superuser: module references __file__
drozer.modules.exploit.soceng.usb_debugging: module references __file__
drozer.modules.exploit.fileformat.polaris_viewer4_bof_web: module references __file__
drozer.modules.exploit.fileformat.polaris_viewer4_generate.polaris_viewer4_bof_generator: module references __file__
pydiesel.reflection.utils.class_loader: module references __file__
creating 'dist/drozer-2.4.1-py2.7.egg' and adding 'build/bdist.linux-i686/egg' to it
removing 'build/bdist.linux-i686/egg' (and everything under it)
Processing drozer-2.4.1-py2.7.egg
removing '/root/.virtualenvs/drozer/lib/python2.7/site-packages/drozer-2.4.1-py2.7.egg' (and everything under it)
creating /root/.virtualenvs/drozer/lib/python2.7/site-packages/drozer-2.4.1-py2.7.egg
Extracting drozer-2.4.1-py2.7.egg to /root/.virtualenvs/drozer/lib/python2.7/site-packages
drozer 2.4.1 is already the active version in easy-install.pth
Installing drozer-complete script to /root/.virtualenvs/drozer/bin
Installing drozer script to /root/.virtualenvs/drozer/bin

Installed /root/.virtualenvs/drozer/lib/python2.7/site-packages/drozer-2.4.1-py2.7.egg
Processing dependencies for drozer==2.4.1
Searching for PyYAML==3.11
Best match: PyYAML 3.11
Processing PyYAML-3.11-py2.7-linux-i686.egg
PyYAML 3.11 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/PyYAML-3.11-py2.7-linux-i686.egg
Searching for pyOpenSSL==0.15
Best match: pyOpenSSL 0.15
Processing pyOpenSSL-0.15-py2.7.egg
pyOpenSSL 0.15 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/pyOpenSSL-0.15-py2.7.egg
Searching for protobuf==2.6.1
Best match: protobuf 2.6.1
Processing protobuf-2.6.1-py2.7.egg
protobuf 2.6.1 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/protobuf-2.6.1-py2.7.egg
Searching for six==1.10.0
Best match: six 1.10.0
Processing six-1.10.0-py2.7.egg
six 1.10.0 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/six-1.10.0-py2.7.egg
Searching for cryptography==1.7
Best match: cryptography 1.7
Processing cryptography-1.7-py2.7-linux-i686.egg
cryptography 1.7 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/cryptography-1.7-py2.7-linux-i686.egg
Searching for setuptools==31.0.0
Best match: setuptools 31.0.0
Adding setuptools 31.0.0 to easy-install.pth file
Installing easy_install-3.5 script to /root/.virtualenvs/drozer/bin
Installing easy_install script to /root/.virtualenvs/drozer/bin

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages
Searching for cffi==1.9.1
Best match: cffi 1.9.1
Processing cffi-1.9.1-py2.7-linux-i686.egg
cffi 1.9.1 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/cffi-1.9.1-py2.7-linux-i686.egg
Searching for ipaddress==1.0.17
Best match: ipaddress 1.0.17
Processing ipaddress-1.0.17-py2.7.egg
ipaddress 1.0.17 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/ipaddress-1.0.17-py2.7.egg
Searching for enum34==1.1.6
Best match: enum34 1.1.6
Processing enum34-1.1.6-py2.7.egg
enum34 1.1.6 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/enum34-1.1.6-py2.7.egg
Searching for pyasn1==0.1.9
Best match: pyasn1 0.1.9
Processing pyasn1-0.1.9-py2.7.egg
pyasn1 0.1.9 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/pyasn1-0.1.9-py2.7.egg
Searching for idna==2.1
Best match: idna 2.1
Processing idna-2.1-py2.7.egg
idna 2.1 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/idna-2.1-py2.7.egg
Searching for pycparser==2.17
Best match: pycparser 2.17
Processing pycparser-2.17-py2.7.egg
pycparser 2.17 is already the active version in easy-install.pth

Using /root/.virtualenvs/drozer/lib/python2.7/site-packages/pycparser-2.17-py2.7.egg
Finished processing dependencies for drozer==2.4.1
```