### PR TITLE
Update path of compiled wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ python setup.py bdist_wheel
 ### Installing Python wheel
 
 ```
-sudo pip install drozer-2.x.x-py2-none-any.whl
+sudo pip install dist/drozer-2.x.x-py2-none-any.whl
 
 ```
 


### PR DESCRIPTION
drozer-2.x.x-py2-none-any.whl is located at `drozer/dist/` by default.