### PR TITLE
Don't shell out to cut, support Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,12 +118,14 @@ def get_package_data():
 	return data
 
 def get_version():
-	version_cmd = ['git', 'describe', '--tags', '|' ,'cut', '-c', '1-5']
-
-	if platform == "linux2" or platform == "linux" or platform == "darwin":
-		return subprocess.check_output(' '.join(version_cmd),shell=True)
-	elif platform == "win32":
-		return subprocess.check_output(version_cmd,shell=True)
+	version_cmd = ['git', 'describe', '--tags']
+	
+	if platform in ("linux2", "linux", "darwin"):
+		version_cmd = ' '.join(version_cmd)
+	elif platform != "win32":
+		return
+	
+	return subprocess.check_output(version_cmd).split('-', 1)[0]
 
 setuptools.setup(
   name = meta.name,


### PR DESCRIPTION
Use python str.split instead of shelling out to cut.
Support Windows (where cut command is not usually available), fixes #328.
shell=True is not necessary.
Also, its unclear why version_cmd is joined into a string for certain platforms, the joined version works fine on my Windows 10 machine and the unjoined version works fine on my Debian-based. Passing version_cmd as a list should work on all platforms as far as I know?